### PR TITLE
Fix subtitle grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [ ![Download](https://api.bintray.com/packages/fewlaps/maven/abtesting-android/images/download.svg) ](https://bintray.com/fewlaps/maven/abtesting-android/_latestVersion)
 
 # A/B Testing
-The simpler A/B Testing library
+The simplest A/B Testing library
 
 Create an experiment, set some options for them, and test the user's behaviour asap!
 


### PR DESCRIPTION
I believe that instead of 

> The simpler A/B Testing library

you want to say

> The simplest A/B Testing library

Also,
- [x] It that is the case, you should also update the repo description.

☮️ ❤️ 